### PR TITLE
feat: Add frontend for Automated Journey Management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import { Routes, Route, Navigate, Link } from 'react-router-dom';
+import { Routes, Route, Navigate, Link, Outlet } from 'react-router-dom';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import Login from './pages/Login';
 import Register from './pages/Register';
-import { Box, Button } from '@mui/material';
+import { Box, Button, AppBar, Toolbar, Typography } from '@mui/material';
+
+// Import new journey pages
+import JourneyListPage from './pages/journeys/JourneyListPage';
+import JourneyCreator from './pages/journeys/JourneyCreator';
+import JourneyEditor from './pages/journeys/JourneyEditor';
+import JourneyDetailPage from './pages/journeys/JourneyDetailPage';
 
 const Protected: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user } = useAuth();
@@ -11,15 +17,42 @@ const Protected: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return <>{children}</>;
 };
 
-function DashboardStub() {
-  const { user, logout } = useAuth();
-  return (
-    <Box sx={{ p: 3, display: 'grid', gap: 2 }}>
-      <h2>Welcome, {user?.email}</h2>
-      <p>Login worked. Replace this with your real dashboard later.</p>
-      <Button variant="outlined" component={Link} to="/login" onClick={logout}>Logout</Button>
-    </Box>
-  );
+// New Layout component with persistent navigation
+function Layout() {
+    const { user, logout } = useAuth();
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+            <AppBar position="static">
+                <Toolbar>
+                    <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+                        CXQ Automation
+                    </Typography>
+                    <Button color="inherit" component={Link} to="/">Dashboard</Button>
+                    <Button color="inherit" component={Link} to="/journeys">Journeys</Button>
+                    <Button color="inherit" onClick={logout}>Logout ({user?.email})</Button>
+                </Toolbar>
+            </AppBar>
+            <Box
+              component="main"
+              sx={{
+                flexGrow: 1,
+                p: 3,
+                overflow: 'auto'
+              }}
+            >
+                <Outlet /> {/* Child routes will render here */}
+            </Box>
+        </Box>
+    );
+}
+
+function Dashboard() {
+    return (
+        <Box>
+            <Typography variant="h4">Dashboard</Typography>
+            <Typography>Welcome to your dashboard. Select an option from the navigation bar.</Typography>
+        </Box>
+    )
 }
 
 function AppInner() {
@@ -27,7 +60,14 @@ function AppInner() {
     <Routes>
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
-      <Route path="/" element={<Protected><DashboardStub /></Protected>} />
+      <Route path="/" element={<Protected><Layout /></Protected>}>
+        {/* Nested routes that use the Layout */}
+        <Route index element={<Dashboard />} />
+        <Route path="journeys" element={<JourneyListPage />} />
+        <Route path="journeys/new" element={<JourneyCreator />} />
+        <Route path="journeys/edit/:id" element={<JourneyEditor />} />
+        <Route path="journeys/:id" element={<JourneyDetailPage />} />
+      </Route>
     </Routes>
   );
 }

--- a/frontend/src/api/journeys.ts
+++ b/frontend/src/api/journeys.ts
@@ -1,0 +1,53 @@
+import api from './axios';
+
+// Basic types for Journey data. These should match the backend models.
+export interface JourneyStep {
+  action: 'goto' | 'click' | 'type' | 'waitForSelector';
+  params: {
+    selector?: string;
+    url?: string;
+    text?: string;
+  };
+}
+
+export interface Journey {
+  _id: string;
+  name: string;
+  steps: JourneyStep[];
+  user: string;
+  lastRun?: {
+    status: 'success' | 'failure' | 'pending';
+    runAt: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const getJourneys = async (): Promise<Journey[]> => {
+  const response = await api.get('/api/journeys');
+  return response.data;
+};
+
+export const getJourney = async (id: string): Promise<Journey> => {
+  const response = await api.get(`/api/journeys/${id}`);
+  return response.data;
+};
+
+export const createJourney = async (data: { name: string; steps: JourneyStep[] }): Promise<Journey> => {
+  const response = await api.post('/api/journeys', data);
+  return response.data;
+};
+
+export const updateJourney = async (id: string, data: { name: string; steps: JourneyStep[] }): Promise<Journey> => {
+  const response = await api.put(`/api/journeys/${id}`, data);
+  return response.data;
+};
+
+export const deleteJourney = async (id: string): Promise<void> => {
+  await api.delete(`/api/journeys/${id}`);
+};
+
+export const runJourney = async (id: string): Promise<{ message: string }> => {
+  const response = await api.post(`/api/journeys/${id}/run`);
+  return response.data;
+};

--- a/frontend/src/pages/journeys/JourneyCreator.tsx
+++ b/frontend/src/pages/journeys/JourneyCreator.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Box, Typography, Paper, Alert } from '@mui/material';
+import JourneyForm from './JourneyForm';
+import { createJourney, JourneyStep } from '../../api/journeys';
+
+export default function JourneyCreator() {
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (data: { name: string; steps: JourneyStep[] }) => {
+    try {
+      await createJourney(data);
+      navigate('/journeys');
+    } catch (err) {
+      setError('Failed to create journey. Please check your input and try again.');
+      console.error(err);
+    }
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
+        Create New Journey
+      </Typography>
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      <Paper>
+        <JourneyForm onSubmit={handleSubmit} />
+      </Paper>
+    </Box>
+  );
+}

--- a/frontend/src/pages/journeys/JourneyDetailPage.tsx
+++ b/frontend/src/pages/journeys/JourneyDetailPage.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, Link as RouterLink } from 'react-router-dom';
+import {
+  Box,
+  Typography,
+  Paper,
+  Alert,
+  CircularProgress,
+  List,
+  ListItem,
+  ListItemText,
+  Divider,
+  Grid,
+  Chip,
+  Button,
+} from '@mui/material';
+import { getJourney, Journey } from '../../api/journeys';
+import { ArrowBack } from '@mui/icons-material';
+
+export default function JourneyDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [journey, setJourney] = useState<Journey | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) {
+      setError("No journey ID provided.");
+      setLoading(false);
+      return;
+    }
+    const fetchJourneyData = async () => {
+      try {
+        const data = await getJourney(id);
+        setJourney(data);
+      } catch (err) {
+        setError('Failed to fetch journey details.');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchJourneyData();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error" sx={{ m: 3 }}>{error}</Alert>;
+  }
+
+  if (!journey) {
+    return <Alert severity="info" sx={{ m: 3 }}>Journey not found.</Alert>;
+  }
+
+  const getStatusChip = (status: 'success' | 'failure' | 'pending' | undefined) => {
+    if (!status) return <Chip label="Not Run" />;
+    switch (status) {
+      case 'success':
+        return <Chip label="Success" color="success" />;
+      case 'failure':
+        return <Chip label="Failure" color="error" />;
+      case 'pending':
+        return <Chip label="Pending" color="warning" />;
+    }
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Button component={RouterLink} to="/journeys" startIcon={<ArrowBack />} sx={{ mb: 2 }}>
+        Back to Journeys
+      </Button>
+      <Paper sx={{ p: 3 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          {journey.name}
+        </Typography>
+        <Divider sx={{ my: 2 }} />
+
+        <Grid container spacing={2} sx={{ mb: 2 }}>
+          <Grid item xs={12} sm={6}>
+            <Typography variant="h6">Last Run</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 1 }}>
+                {getStatusChip(journey.lastRun?.status)}
+                <Typography variant="body2" color="text.secondary">
+                    {journey.lastRun?.runAt ? new Date(journey.lastRun.runAt).toLocaleString() : 'Never'}
+                </Typography>
+            </Box>
+          </Grid>
+           <Grid item xs={12} sm={6}>
+            <Typography variant="h6">Details</Typography>
+            <Typography variant="body2" color="text.secondary">
+                Created: {new Date(journey.createdAt).toLocaleString()}
+            </Typography>
+             <Typography variant="body2" color="text.secondary">
+                Last Updated: {new Date(journey.updatedAt).toLocaleString()}
+            </Typography>
+          </Grid>
+        </Grid>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Typography variant="h6" gutterBottom>
+          Steps
+        </Typography>
+        <List>
+          {journey.steps.map((step, index) => (
+            <ListItem key={index} divider>
+              <ListItemText
+                primary={<Typography variant="body1" component="span" sx={{ fontWeight: 'bold' }}>{step.action}</Typography>}
+                secondary={
+                  <Box component="pre" sx={{ m: 0, p: 0, fontFamily: 'monospace', whiteSpace: 'pre-wrap' }}>
+                    {JSON.stringify(step.params, null, 2)}
+                  </Box>
+                }
+              />
+            </ListItem>
+          ))}
+        </List>
+      </Paper>
+    </Box>
+  );
+}

--- a/frontend/src/pages/journeys/JourneyEditor.tsx
+++ b/frontend/src/pages/journeys/JourneyEditor.tsx
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Box, Typography, Paper, Alert, CircularProgress } from '@mui/material';
+import JourneyForm from './JourneyForm';
+import { getJourney, updateJourney, Journey, JourneyStep } from '../../api/journeys';
+
+export default function JourneyEditor() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [initialData, setInitialData] = useState<{ name: string; steps: JourneyStep[] } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) {
+      setError("No journey ID provided.");
+      setLoading(false);
+      return;
+    }
+    const fetchJourneyData = async () => {
+      try {
+        const journey = await getJourney(id);
+        setInitialData({ name: journey.name, steps: journey.steps });
+      } catch (err) {
+        setError('Failed to fetch journey data.');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchJourneyData();
+  }, [id]);
+
+  const handleSubmit = async (data: { name: string; steps: JourneyStep[] }) => {
+    if (!id) return;
+    try {
+      await updateJourney(id, data);
+      navigate('/journeys');
+    } catch (err) {
+      setError('Failed to update journey.');
+      console.error(err);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error" sx={{ m: 3 }}>{error}</Alert>;
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
+        Edit Journey
+      </Typography>
+      <Paper>
+        {initialData ? (
+          <JourneyForm
+            onSubmit={handleSubmit}
+            initialData={initialData}
+            submitButtonText="Update Journey"
+          />
+        ) : (
+          <Alert severity="info">Journey data could not be loaded.</Alert>
+        )}
+      </Paper>
+    </Box>
+  );
+}

--- a/frontend/src/pages/journeys/JourneyForm.tsx
+++ b/frontend/src/pages/journeys/JourneyForm.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  Paper,
+  IconButton,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Grid,
+} from '@mui/material';
+import { AddCircle, Delete } from '@mui/icons-material';
+import { JourneyStep } from '../../api/journeys';
+
+interface JourneyFormProps {
+  onSubmit: (data: { name: string; steps: JourneyStep[] }) => void;
+  initialData?: { name: string; steps: JourneyStep[] };
+  submitButtonText?: string;
+}
+
+const defaultStep: JourneyStep = {
+  action: 'goto',
+  params: { url: 'https://www.saucedemo.com' },
+};
+
+export default function JourneyForm({
+  onSubmit,
+  initialData = { name: '', steps: [defaultStep] },
+  submitButtonText = 'Create Journey',
+}: JourneyFormProps) {
+  const [name, setName] = useState(initialData.name);
+  const [steps, setSteps] = useState<JourneyStep[]>(initialData.steps);
+
+  const handleStepChange = (index: number, field: keyof JourneyStep | keyof JourneyStep['params'], value: any) => {
+    const newSteps = [...steps];
+    if (field === 'action') {
+      newSteps[index] = { ...newSteps[index], action: value, params: {} }; // Reset params on action change
+    } else if (field in newSteps[index]) {
+      (newSteps[index] as any)[field] = value;
+    } else {
+      newSteps[index].params = { ...newSteps[index].params, [field]: value };
+    }
+    setSteps(newSteps);
+  };
+
+  const addStep = () => {
+    setSteps([...steps, { ...defaultStep }]);
+  };
+
+  const removeStep = (index: number) => {
+    setSteps(steps.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ name, steps });
+  };
+
+  const renderStepParams = (step: JourneyStep, index: number) => {
+    switch (step.action) {
+      case 'goto':
+        return (
+          <TextField
+            label="URL"
+            value={step.params.url || ''}
+            onChange={(e) => handleStepChange(index, 'url', e.target.value)}
+            fullWidth
+            required
+          />
+        );
+      case 'click':
+      case 'waitForSelector':
+        return (
+          <TextField
+            label="Selector"
+            value={step.params.selector || ''}
+            onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
+            fullWidth
+            required
+          />
+        );
+      case 'type':
+        return (
+          <>
+            <Grid item xs={6}>
+              <TextField
+                label="Selector"
+                value={step.params.selector || ''}
+                onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={6}>
+              <TextField
+                label="Text"
+                value={step.params.text || ''}
+                onChange={(e) => handleStepChange(index, 'text', e.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+          </>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ p: 3 }}>
+      <TextField
+        label="Journey Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        fullWidth
+        required
+        sx={{ mb: 3 }}
+      />
+
+      <Typography variant="h6" sx={{ mb: 1 }}>Steps</Typography>
+
+      {steps.map((step, index) => (
+        <Paper key={index} sx={{ p: 2, mb: 2 }}>
+          <Grid container spacing={2} alignItems="center">
+            <Grid item xs={12} sm={4}>
+              <FormControl fullWidth>
+                <InputLabel>Action</InputLabel>
+                <Select
+                  value={step.action}
+                  label="Action"
+                  onChange={(e) => handleStepChange(index, 'action', e.target.value)}
+                >
+                  <MenuItem value="goto">Go To</MenuItem>
+                  <MenuItem value="click">Click</MenuItem>
+                  <MenuItem value="type">Type</MenuItem>
+                  <MenuItem value="waitForSelector">Wait For Selector</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12} sm={7}>
+              <Grid container spacing={2}>
+                {renderStepParams(step, index)}
+              </Grid>
+            </Grid>
+            <Grid item xs={12} sm={1}>
+              <IconButton onClick={() => removeStep(index)} color="error">
+                <Delete />
+              </IconButton>
+            </Grid>
+          </Grid>
+        </Paper>
+      ))}
+
+      <Button
+        type="button"
+        onClick={addStep}
+        startIcon={<AddCircle />}
+        sx={{ mr: 2 }}
+      >
+        Add Step
+      </Button>
+
+      <Button type="submit" variant="contained">
+        {submitButtonText}
+      </Button>
+    </Box>
+  );
+}

--- a/frontend/src/pages/journeys/JourneyListPage.tsx
+++ b/frontend/src/pages/journeys/JourneyListPage.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  CircularProgress,
+  Alert,
+  Chip,
+} from '@mui/material';
+import { Add, Edit, Delete, PlayArrow, Visibility } from '@mui/icons-material';
+import { getJourneys, deleteJourney, runJourney, Journey } from '../../api/journeys';
+
+export default function JourneyListPage() {
+  const [journeys, setJourneys] = useState<Journey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchJourneys = async () => {
+    try {
+      setLoading(true);
+      const data = await getJourneys();
+      setJourneys(data);
+    } catch (err) {
+      setError('Failed to fetch journeys. Please try again later.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchJourneys();
+  }, []);
+
+  const handleDelete = async (id: string) => {
+    if (window.confirm('Are you sure you want to delete this journey?')) {
+      try {
+        await deleteJourney(id);
+        setJourneys(journeys.filter((j) => j._id !== id));
+      } catch (err) {
+        setError('Failed to delete journey.');
+      }
+    }
+  };
+
+  const handleRun = async (id: string) => {
+    try {
+      await runJourney(id);
+      alert('Journey execution started successfully.');
+      // Optionally, refresh the list to show the updated 'lastRun' status
+      fetchJourneys();
+    } catch (err) {
+      setError('Failed to start journey execution.');
+    }
+  };
+
+  const getStatusChip = (status: 'success' | 'failure' | 'pending' | undefined) => {
+    if (!status) return <Chip label="Not Run" size="small" />;
+    switch (status) {
+      case 'success':
+        return <Chip label="Success" color="success" size="small" />;
+      case 'failure':
+        return <Chip label="Failure" color="error" size="small" />;
+      case 'pending':
+        return <Chip label="Pending" color="warning" size="small" />;
+    }
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
+        <Typography variant="h4" component="h1">
+          Journeys
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<Add />}
+          component={RouterLink}
+          to="/journeys/new"
+        >
+          Create New Journey
+        </Button>
+      </Box>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Last Run Status</TableCell>
+              <TableCell>Last Run At</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {journeys.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} align="center">
+                  No journeys found. Create one to get started!
+                </TableCell>
+              </TableRow>
+            ) : (
+              journeys.map((journey) => (
+                <TableRow key={journey._id}>
+                  <TableCell>{journey.name}</TableCell>
+                  <TableCell>{getStatusChip(journey.lastRun?.status)}</TableCell>
+                  <TableCell>
+                    {journey.lastRun?.runAt ? new Date(journey.lastRun.runAt).toLocaleString() : 'N/A'}
+                  </TableCell>
+                  <TableCell>
+                    <IconButton component={RouterLink} to={`/journeys/${journey._id}`} title="View Details">
+                      <Visibility />
+                    </IconButton>
+                    <IconButton component={RouterLink} to={`/journeys/edit/${journey._id}`} title="Edit">
+                      <Edit />
+                    </IconButton>
+                    <IconButton onClick={() => handleRun(journey._id)} title="Run Journey">
+                      <PlayArrow />
+                    </IconButton>
+                    <IconButton onClick={() => handleDelete(journey._id)} title="Delete">
+                      <Delete />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}


### PR DESCRIPTION
This commit introduces a complete frontend user interface for the Automated Journey Management feature. Users can now create, view, update, delete, and run test journeys from the UI.

Key additions:
- A new set of React components under `frontend/src/pages/journeys/` for listing, creating, editing, and viewing journeys.
- A dynamic form (`JourneyForm.tsx`) for defining multi-step journeys.
- An API service (`frontend/src/api/journeys.ts`) to communicate with the backend journey endpoints.
- Updated application routing in `frontend/src/App.tsx` to include the new pages within a persistent, authenticated layout.