### PR TITLE
fix: Correct type-only imports for Journey interfaces

### DIFF
--- a/frontend/src/pages/journeys/JourneyCreator.tsx
+++ b/frontend/src/pages/journeys/JourneyCreator.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, Typography, Paper, Alert } from '@mui/material';
 import JourneyForm from './JourneyForm';
-import { createJourney, JourneyStep } from '../../api/journeys';
+import { createJourney, type JourneyStep } from '../../api/journeys';
 
 export default function JourneyCreator() {
   const navigate = useNavigate();

--- a/frontend/src/pages/journeys/JourneyDetailPage.tsx
+++ b/frontend/src/pages/journeys/JourneyDetailPage.tsx
@@ -14,7 +14,7 @@ import {
   Chip,
   Button,
 } from '@mui/material';
-import { getJourney, Journey } from '../../api/journeys';
+import { getJourney, type Journey } from '../../api/journeys';
 import { ArrowBack } from '@mui/icons-material';
 
 export default function JourneyDetailPage() {

--- a/frontend/src/pages/journeys/JourneyEditor.tsx
+++ b/frontend/src/pages/journeys/JourneyEditor.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Box, Typography, Paper, Alert, CircularProgress } from '@mui/material';
 import JourneyForm from './JourneyForm';
-import { getJourney, updateJourney, Journey, JourneyStep } from '../../api/journeys';
+import { getJourney, updateJourney, type Journey, type JourneyStep } from '../../api/journeys';
 
 export default function JourneyEditor() {
   const { id } = useParams<{ id: string }>();

--- a/frontend/src/pages/journeys/JourneyForm.tsx
+++ b/frontend/src/pages/journeys/JourneyForm.tsx
@@ -13,7 +13,7 @@ import {
   Grid,
 } from '@mui/material';
 import { AddCircle, Delete } from '@mui/icons-material';
-import { JourneyStep } from '../../api/journeys';
+import type { JourneyStep } from '../../api/journeys';
 
 interface JourneyFormProps {
   onSubmit: (data: { name: string; steps: JourneyStep[] }) => void;

--- a/frontend/src/pages/journeys/JourneyListPage.tsx
+++ b/frontend/src/pages/journeys/JourneyListPage.tsx
@@ -17,7 +17,7 @@ import {
   Chip,
 } from '@mui/material';
 import { Add, Edit, Delete, PlayArrow, Visibility } from '@mui/icons-material';
-import { getJourneys, deleteJourney, runJourney, Journey } from '../../api/journeys';
+import { getJourneys, deleteJourney, runJourney, type Journey } from '../../api/journeys';
 
 export default function JourneyListPage() {
   const [journeys, setJourneys] = useState<Journey[]>([]);


### PR DESCRIPTION
This commit fixes a runtime error caused by improper handling of TypeScript type imports by the browser's module loader.

The error "The requested module does not provide an export named '...'" occurs because TypeScript interfaces are removed at compile time, and the bundler was not correctly identifying them as type-only.

The fix is to explicitly mark the imports of `Journey` and `JourneyStep` interfaces with the `type` keyword (e.g., `import type { Journey } from '...'`). This ensures they are properly erased from the JavaScript output and resolves the browser error.