### PR TITLE
fix: Apply authorization fix to PUT notification settings route

### DIFF
--- a/backend/src/routes/notificationSettings.js
+++ b/backend/src/routes/notificationSettings.js
@@ -49,7 +49,7 @@ router.put('/:journeyId', auth, async (req, res) => {
       return res.status(404).json({ msg: 'Journey not found' });
     }
 
-    if (journey.user.toString() !== req.user.id) {
+    if (!journey.user.equals(req.user.id)) {
       return res.status(401).json({ msg: 'User not authorized' });
     }
 


### PR DESCRIPTION
This commit resolves a `401 Unauthorized` error that occurred when updating notification settings. The root cause was the same as a previous bug: an incorrect comparison of Mongoose ObjectIds.

The authorization check in the `PUT /api/notification-settings/:journeyId` route handler has been updated to use the `.equals()` method. This ensures the ownership check is performed correctly, aligning it with the logic in the `GET` route and other protected endpoints.