### PR TITLE
feat: implement frontend for journey templates

### DIFF
--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -1,0 +1,12 @@
+import axios from './axios';
+
+export interface Template {
+  name: string;
+  description: string;
+  steps: any[]; // You might want to define a more specific type for steps
+}
+
+export const getTemplates = async (): Promise<Template[]> => {
+  const response = await axios.get('/templates');
+  return response.data;
+};

--- a/frontend/src/components/JourneyTemplates.tsx
+++ b/frontend/src/components/JourneyTemplates.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  Paper,
+  CircularProgress,
+  Alert as MuiAlert,
+  Button,
+} from '@mui/material';
+import { getTemplates, type Template } from '../api/templates';
+
+export default function JourneyTemplates() {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchTemplates = async () => {
+      try {
+        setLoading(true);
+        const data = await getTemplates();
+        setTemplates(data);
+      } catch (err) {
+        setError('Failed to fetch templates. Please try again later.');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTemplates();
+  }, []);
+
+  const handleSelectTemplate = (template: Template) => {
+    navigate('/journeys/new', { state: { template } });
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Paper sx={{ p: 2, mt: 3 }}>
+      <Typography variant="h6" component="h2" gutterBottom>
+        Create from a Template
+      </Typography>
+      {error && <MuiAlert severity="error" sx={{ mb: 2 }}>{error}</MuiAlert>}
+      <List>
+        {templates.map((template) => (
+          <ListItem
+            key={template.name}
+            secondaryAction={
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={() => handleSelectTemplate(template)}
+              >
+                Use Template
+              </Button>
+            }
+          >
+            <ListItemText
+              primary={template.name}
+              secondary={template.description}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </Paper>
+  );
+}

--- a/frontend/src/pages/journeys/JourneyCreator.tsx
+++ b/frontend/src/pages/journeys/JourneyCreator.tsx
@@ -1,12 +1,47 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { Box, Typography, Paper, Alert } from '@mui/material';
 import JourneyForm from './JourneyForm';
 import { createJourney, type JourneyStep } from '../../api/journeys';
+import { Template } from '../../api/templates';
 
 export default function JourneyCreator() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const templateData = location.state?.template as Template | undefined;
+
   const [error, setError] = useState<string | null>(null);
+
+  const transformTemplateToInitialData = (template: Template | undefined) => {
+    if (!template) {
+      return undefined;
+    }
+
+    const transformedSteps: JourneyStep[] = template.steps
+      .map((step): JourneyStep | null => {
+        switch (step.action) {
+          case 'navigate':
+            return { action: 'goto', params: { url: step.value } };
+          case 'click':
+            return { action: 'click', params: { selector: step.selector } };
+          case 'type':
+            return { action: 'type', params: { selector: step.selector, text: step.value } };
+          case 'waitForSelector':
+            return { action: 'waitForSelector', params: { selector: step.selector } };
+          default:
+            // Ignore unsupported actions for now
+            return null;
+        }
+      })
+      .filter((step): step is JourneyStep => step !== null);
+
+    return {
+      name: template.name,
+      steps: transformedSteps,
+    };
+  };
+
+  const initialData = transformTemplateToInitialData(templateData);
 
   const handleSubmit = async (data: { name: string; steps: JourneyStep[] }) => {
     try {
@@ -21,11 +56,11 @@ export default function JourneyCreator() {
   return (
     <Box sx={{ p: 3 }}>
       <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
-        Create New Journey
+        {templateData ? `Create Journey from "${templateData.name}"` : 'Create New Journey'}
       </Typography>
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
       <Paper>
-        <JourneyForm onSubmit={handleSubmit} />
+        <JourneyForm onSubmit={handleSubmit} initialData={initialData} />
       </Paper>
     </Box>
   );

--- a/frontend/src/pages/journeys/JourneyListPage.tsx
+++ b/frontend/src/pages/journeys/JourneyListPage.tsx
@@ -22,6 +22,7 @@ import { Add, Edit, Delete, PlayArrow, Visibility, FileUpload, Settings } from '
 import { getJourneys, deleteJourney, runJourney, type Journey } from '../../api/journeys';
 import LiveAlerts from '../../components/LiveAlerts';
 import AlertBanner from '../../components/AlertBanner';
+import JourneyTemplates from '../../components/JourneyTemplates';
 
 export default function JourneyListPage() {
   const [journeys, setJourneys] = useState<Journey[]>([]);
@@ -171,6 +172,7 @@ export default function JourneyListPage() {
           <Paper sx={{ p: 2 }}>
             <LiveAlerts />
           </Paper>
+          <JourneyTemplates />
         </Grid>
       </Grid>
     </Box>


### PR DESCRIPTION
- Adds a new `JourneyTemplates` component to display the list of available templates.
- Integrates the `JourneyTemplates` component into the `JourneyListPage`.
- Updates `JourneyCreator` to accept template data from the navigation state and pre-fill the journey creation form.
- Adds a new API service to fetch the templates from the backend.