### PR TITLE
fix: use type-only import for Template interface

### DIFF
--- a/frontend/src/pages/journeys/JourneyCreator.tsx
+++ b/frontend/src/pages/journeys/JourneyCreator.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { Box, Typography, Paper, Alert } from '@mui/material';
 import JourneyForm from './JourneyForm';
 import { createJourney, type JourneyStep } from '../../api/journeys';
-import { Template } from '../../api/templates';
+import type { Template } from '../../api/templates';
 
 export default function JourneyCreator() {
   const navigate = useNavigate();


### PR DESCRIPTION
- Updates the import statement for the `Template` interface in `JourneyCreator.tsx` to be a type-only import (`import type`).
- This fixes a runtime error where the browser would try to import a value that doesn't exist at runtime, as TypeScript interfaces are compile-time only.