### PR TITLE
fix: correct API path for templates endpoint

### DIFF
--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -7,6 +7,6 @@ export interface Template {
 }
 
 export const getTemplates = async (): Promise<Template[]> => {
-  const response = await axios.get('/templates');
+  const response = await axios.get('/api/templates');
   return response.data;
 };


### PR DESCRIPTION
- Updates the `getTemplates` function in `frontend/src/api/templates.ts` to use the correct API path `/api/templates`.
- This fixes a 404 Not Found error that occurred when the frontend tried to fetch the journey templates.