### PR TITLE
fix: add openai as a dependency

### DIFF
--- a/backend/backend/package-lock.json
+++ b/backend/backend/package-lock.json
@@ -7,7 +7,8 @@
       "dependencies": {
         "@babel/parser": "^7.28.3",
         "@babel/traverse": "^7.28.3",
-        "nodemailer": "^7.0.6"
+        "nodemailer": "^7.0.6",
+        "openai": "^5.19.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -210,6 +211,27 @@
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.19.1.tgz",
+      "integrity": "sha512-zSqnUF7oR9ksmpusKkpUgkNrj8Sl57U+OyzO8jzc7LUjTMg4DRfR3uCm+EIMA6iw06sRPNp4t7ojp3sCpEUZRQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/picocolors": {

--- a/backend/backend/package.json
+++ b/backend/backend/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@babel/parser": "^7.28.3",
     "@babel/traverse": "^7.28.3",
-    "nodemailer": "^7.0.6"
+    "nodemailer": "^7.0.6",
+    "openai": "^5.19.1"
   }
 }


### PR DESCRIPTION
- Adds the `openai` package to the backend's `package.json`.
- This resolves the `MODULE_NOT_FOUND` error that was causing the server to crash.