### PR TITLE
feat: Implement Playwright Assertions

### DIFF
--- a/backend/src/constants/journeyTemplates.js
+++ b/backend/src/constants/journeyTemplates.js
@@ -98,6 +98,16 @@ const journeyTemplates = [
       { action: 'navigate', value: '/' },
       { action: 'checkLinks' }
     ]
+  },
+  {
+    name: 'Assertion Demo',
+    description: 'A journey to demonstrate the new assertion capabilities.',
+    steps: [
+      { action: 'navigate', value: 'https://playwright.dev/' },
+      { action: 'toBeVisible', selector: 'nav >> text=Docs' },
+      { action: 'toHaveText', selector: 'h1', text: 'Playwright enables reliable end-to-end testing for modern web apps.' },
+      { action: 'toHaveAttribute', selector: 'nav >> a', attribute: 'href', value: '/docs/intro' },
+    ]
   }
 ];
 

--- a/backend/src/services/llm.js
+++ b/backend/src/services/llm.js
@@ -20,6 +20,13 @@ Each object in the "steps" array must have an "action" and a "params" object. Th
   - params: { "selector": "...", "text": "..." }
 - "waitForSelector": Waits for an element to be present on the page.
   - params: { "selector": "..." }
+- "toBeVisible": Asserts that an element is visible.
+  - params: { "selector": "...", "not": false }
+- "toHaveText": Asserts that an element has the given text.
+  - params: { "selector": "...", "text": "...", "not": false }
+- "toHaveAttribute": Asserts that an element has the given attribute with the given value.
+  - params: { "selector": "...", "attribute": "...", "value": "...", "not": false }
+
 
 You must only use the actions listed above. For selectors, use standard CSS selectors. Be precise.
 
@@ -57,9 +64,11 @@ Your JSON output:
       }
     },
     {
-      "action": "waitForSelector",
+      "action": "toHaveText",
       "params": {
-        "selector": "//*[contains(text(), 'Welcome back!')]"
+        "selector": "body",
+        "text": "Welcome back!",
+        "not": false
       }
     }
   ]

--- a/frontend/src/api/journeys.ts
+++ b/frontend/src/api/journeys.ts
@@ -5,11 +5,14 @@ import api from './axios';
 type Selector = string | { method: string; args: any[] };
 
 export interface JourneyStep {
-  action: 'goto' | 'click' | 'type' | 'waitForSelector';
+  action: 'goto' | 'click' | 'type' | 'waitForSelector' | 'toBeVisible' | 'toHaveText' | 'toHaveAttribute';
   params: {
     selector?: Selector;
     url?: string;
     text?: string;
+    attribute?: string;
+    value?: string;
+    not?: boolean;
   };
 }
 

--- a/frontend/src/pages/journeys/JourneyCreator.tsx
+++ b/frontend/src/pages/journeys/JourneyCreator.tsx
@@ -22,6 +22,15 @@ export default function JourneyCreator() {
             return { action: step.action, params: { selector: step.selector } };
           case 'type':
             return { action: 'type', params: { selector: step.selector, text: step.value } };
+          case 'toBeVisible':
+            return { action: 'toBeVisible', params: { selector: step.selector } };
+          case 'toHaveText':
+            return { action: 'toHaveText', params: { selector: step.selector, text: step.text } };
+          case 'toHaveAttribute':
+            return {
+              action: 'toHaveAttribute',
+              params: { selector: step.selector, attribute: step.attribute, value: step.value },
+            };
           default:
             // For actions like waitForNavigation, waitForText, request, checkLinks
             // that are not supported by the form, we can either ignore them or

--- a/frontend/src/pages/journeys/JourneyForm.tsx
+++ b/frontend/src/pages/journeys/JourneyForm.tsx
@@ -169,6 +169,85 @@ export default function JourneyForm({
             </Grid>
           </>
         );
+      case 'toBeVisible':
+        return (
+          <TextField
+            label="Selector"
+            value={step.params.selector || ''}
+            onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
+            fullWidth
+            required
+          />
+        );
+      case 'toHaveText':
+        return (
+          <>
+            <Grid item xs={6}>
+              <TextField
+                label="Selector"
+                value={step.params.selector || ''}
+                onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={6}>
+              <TextField
+                label="Text"
+                value={step.params.text || ''}
+                onChange={(e) => handleStepChange(index, 'text', e.target.value)}
+                fullWidth
+                required
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <SecretSelector onSelect={(val) => handleStepChange(index, 'text', val)} />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+            </Grid>
+          </>
+        );
+      case 'toHaveAttribute':
+        return (
+          <>
+            <Grid item xs={4}>
+              <TextField
+                label="Selector"
+                value={step.params.selector || ''}
+                onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={4}>
+              <TextField
+                label="Attribute"
+                value={step.params.attribute || ''}
+                onChange={(e) => handleStepChange(index, 'attribute', e.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={4}>
+              <TextField
+                label="Value"
+                value={step.params.value || ''}
+                onChange={(e) => handleStepChange(index, 'value', e.target.value)}
+                fullWidth
+                required
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <SecretSelector onSelect={(val) => handleStepChange(index, 'value', val)} />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+            </Grid>
+          </>
+        );
       default:
         return null;
     }
@@ -214,6 +293,9 @@ export default function JourneyForm({
                   <MenuItem value="click">Click</MenuItem>
                   <MenuItem value="type">Type</MenuItem>
                   <MenuItem value="waitForSelector">Wait For Selector</MenuItem>
+                  <MenuItem value="toBeVisible">Is Visible</MenuItem>
+                  <MenuItem value="toHaveText">Has Text</MenuItem>
+                  <MenuItem value="toHaveAttribute">Has Attribute</MenuItem>
                 </Select>
               </FormControl>
             </Grid>


### PR DESCRIPTION
This commit introduces support for Playwright assertions in journeys.

The following new assertion actions are now available:
- toBeVisible: Asserts that an element is visible.
- toHaveText: Asserts that an element has a specific text content.
- toHaveAttribute: Asserts that an element has a specific attribute with a given value.

The changes include:
- Backend: Updated the automation service to execute these new assertion steps using Playwright's `expect` library.
- Backend: Updated the LLM service to recognize and generate journey steps with assertions from natural language.
- Frontend: Enhanced the journey editor to allow users to add and edit assertion steps in the UI.
- A new journey template has been added to demonstrate the new assertion capabilities.