### PR TITLE
feat: Allow saving journeys as Playwright scripts

### DIFF
--- a/backend/src/models/Journey.js
+++ b/backend/src/models/Journey.js
@@ -4,6 +4,7 @@ const JourneySchema = new mongoose.Schema({
   name: { type: String, required: true },
   domain: { type: String, required: true, trim: true, index: true },
   steps: { type: Array, required: true },
+  code: { type: String },
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   lastRun: {
     status: { type: String, enum: ['success', 'failure', 'pending'], default: 'pending' },

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -20,7 +20,7 @@ router.post('/journey', async (req, res) => {
   try {
     await fs.writeFile(tempFile, code);
 
-    const steps = await parsePlaywrightCode(tempFile);
+    const { steps, domain } = await parsePlaywrightCode(tempFile);
 
     if (steps.length === 0) {
       return res.status(400).json({ error: 'Could not parse any actionable steps from the code provided.' });
@@ -28,7 +28,9 @@ router.post('/journey', async (req, res) => {
 
     const journey = await Journey.create({
       name,
+      domain,
       steps,
+      code,
       user: req.user.id,
     });
 

--- a/backend/src/services/automation.js
+++ b/backend/src/services/automation.js
@@ -1,4 +1,5 @@
 const { chromium, expect } = require('playwright');
+const { exec } = require('child_process');
 const Journey = require('../models/Journey');
 const Secret = require('../models/Secret');
 const { decrypt } = require('./encryption');
@@ -16,114 +17,58 @@ const path = require('path');
 // }
 
 async function runJourney(journey) {
-  const browser = await chromium.launch();
-  const context = await browser.newContext();
-  const page = await context.newPage();
   const logs = [];
   let status = 'success';
-  // let screenshotPath; 
 
   try {
-    // 1. Fetch and decrypt secrets for the user
+    if (!journey.code) {
+      throw new Error('Journey has no code to run.');
+    }
+
     const userSecrets = await Secret.find({ user: journey.user });
     const secretMap = new Map();
     for (const secret of userSecrets) {
       secretMap.set(secret.name, decrypt(secret.value));
     }
 
-    // 2. Create a substitution function
     const substituteSecrets = (text) => {
       if (typeof text !== 'string') return text;
-      // Regex updated to handle optional whitespace around the secret name
       return text.replace(/{{secrets\.\s*([a-zA-Z0-9_]+)\s*}}/g, (match, secretName) => {
         if (secretMap.has(secretName)) {
           return secretMap.get(secretName);
         }
-        // If secret not found, return the placeholder to make it obvious in logs
         logs.push(`Warning: Secret "${secretName}" not found in vault.`);
         return match;
       });
     };
 
-    for (const step of journey.steps) {
-      // 3. Substitute secrets in params before execution
-      const processedParams = {};
-      for (const key in step.params) {
-        processedParams[key] = substituteSecrets(step.params[key]);
-      }
+    const processedCode = substituteSecrets(journey.code);
 
-      logs.push(`Executing action: ${step.action} with params: ${JSON.stringify(processedParams)}`);
+    const tempDir = path.join(__dirname, '..', '..', 'temp_journeys');
+    await fs.promises.mkdir(tempDir, { recursive: true });
+    const tempFile = path.join(tempDir, `run-${journey._id}-${Date.now()}.js`);
+    await fs.promises.writeFile(tempFile, processedCode);
 
-      // Helper function to get a locator object safely from either a string or our structured object
-      const getLocator = (selector) => {
-        if (typeof selector === 'object' && selector.method && Array.isArray(selector.args)) {
-          // It's our structured locator from the parser
-          if (typeof page[selector.method] === 'function') {
-            return page[selector.method](...selector.args);
-          } else {
-            throw new Error(`Unsupported locator method: ${selector.method}`);
-          }
+    await new Promise((resolve) => {
+      exec(`npx playwright test ${tempFile}`, (error, stdout, stderr) => {
+        if (error) {
+          logs.push(`Execution error: ${error.message}`);
+          status = 'failure';
         }
-        // It's a simple string selector for manually created steps
-        return page.locator(selector);
-      };
+        if (stderr) {
+          logs.push(`stderr: ${stderr}`);
+        }
+        logs.push(`stdout: ${stdout}`);
+        resolve();
+      });
+    });
 
-      const getAssertion = (locator, not) => {
-        return not ? expect(locator).not : expect(locator);
-      };
+    await fs.promises.unlink(tempFile);
 
-      switch (step.action) {
-        case 'goto':
-          await page.goto(processedParams.url);
-          break;
-        case 'click':
-          {
-            const locator = getLocator(processedParams.selector);
-            await locator.click();
-          }
-          break;
-        case 'type':
-          {
-            const locator = getLocator(processedParams.selector);
-            await locator.fill(processedParams.text); // Using fill is more robust for locators
-          }
-          break;
-        case 'waitForSelector':
-          // This action is more for manual creation, recorded journeys will have better waits.
-          await page.waitForSelector(processedParams.selector);
-          break;
-        // Assertions
-        case 'toHaveText':
-          {
-            const locator = getLocator(processedParams.selector);
-            await getAssertion(locator, processedParams.not).toHaveText(processedParams.text);
-          }
-          break;
-        case 'toBeVisible':
-          {
-            const locator = getLocator(processedParams.selector);
-            await getAssertion(locator, processedParams.not).toBeVisible();
-          }
-          break;
-        case 'toHaveAttribute':
-          {
-            const locator = getLocator(processedParams.selector);
-            await getAssertion(locator, processedParams.not).toHaveAttribute(processedParams.attribute, processedParams.value);
-          }
-          break;
-        default:
-          throw new Error(`Unsupported action: ${step.action}`);
-      }
-    }
   } catch (error) {
     status = 'failure';
     logs.push(`Error: ${error.message}`);
-    // Screenshot functionality commented out for now
-    // const screenshotFileName = `${journey._id}-${Date.now()}.png`;
-    // screenshotPath = path.join(screenshotsDir, screenshotFileName);
-    // await page.screenshot({ path: screenshotPath });
   } finally {
-    await browser.close();
 
     const testResult = await TestResult.create({
       journey: journey._id,

--- a/frontend/src/api/journeys.ts
+++ b/frontend/src/api/journeys.ts
@@ -30,6 +30,7 @@ export interface Journey {
   name: string;
   domain: string;
   steps: JourneyStep[];
+  code?: string;
   user: string;
   lastRun?: {
     status: 'success' | 'failure' | 'pending';
@@ -55,7 +56,7 @@ export const createJourney = async (data: { name: string; domain: string; steps:
   return response.data;
 };
 
-export const updateJourney = async (id: string, data: { name: string; domain: string; steps: JourneyStep[] }): Promise<Journey> => {
+export const updateJourney = async (id: string, data: { name: string; domain?: string; steps?: JourneyStep[], code?: string }): Promise<Journey> => {
   const response = await api.put(`/api/journeys/${id}`, data);
   return response.data;
 };

--- a/frontend/src/pages/journeys/JourneyDetailPage.tsx
+++ b/frontend/src/pages/journeys/JourneyDetailPage.tsx
@@ -13,13 +13,15 @@ import {
   Grid,
   Chip,
   Button,
+  TextareaAutosize,
 } from '@mui/material';
-import { getJourney, type Journey, type TestResult } from '../../api/journeys';
+import { getJourney, updateJourney, type Journey, type TestResult } from '../../api/journeys';
 import { ArrowBack } from '@mui/icons-material';
 
 export default function JourneyDetailPage() {
   const { id } = useParams<{ id: string }>();
   const [journey, setJourney] = useState<Journey | null>(null);
+  const [code, setCode] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -33,6 +35,7 @@ export default function JourneyDetailPage() {
       try {
         const data = await getJourney(id);
         setJourney(data);
+        setCode(data.code || '');
       } catch (err) {
         setError('Failed to fetch journey details.');
         console.error(err);
@@ -42,6 +45,19 @@ export default function JourneyDetailPage() {
     };
     fetchJourneyData();
   }, [id]);
+
+  const handleSave = async () => {
+    if (!id || !journey) return;
+    try {
+      const updatedJourney = await updateJourney(id, { name: journey.name, code });
+      setJourney(updatedJourney);
+      setCode(updatedJourney.code || '');
+      alert('Journey updated successfully!');
+    } catch (err) {
+      setError('Failed to update journey.');
+      console.error(err);
+    }
+  };
 
   if (loading) {
     return (
@@ -122,6 +138,21 @@ export default function JourneyDetailPage() {
             </ListItem>
           ))}
         </List>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Typography variant="h6" gutterBottom>
+          Code
+        </Typography>
+        <TextareaAutosize
+          minRows={10}
+          style={{ width: '100%', fontFamily: 'monospace', padding: '8px' }}
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+        />
+        <Button variant="contained" onClick={handleSave} sx={{ mt: 2 }}>
+          Save Code
+        </Button>
 
         {journey.lastRun?.testResult && (
           <>


### PR DESCRIPTION
This feature allows users to save their journeys as raw Playwright scripts, which can be edited and run directly.

- The `Journey` model has been updated to include a `code` field to store the raw Playwright script.
- The import process now saves the raw code to the database.
- The `runJourney` service has been updated to execute the Playwright script from the `code` field using `child_process`.
- The frontend has been updated to include a code editor on the journey detail page, allowing users to view and edit the Playwright script.