### PR TITLE
feat: Allow saving journeys as Playwright scripts

### DIFF
--- a/frontend/src/pages/journeys/JourneyDetailPage.tsx
+++ b/frontend/src/pages/journeys/JourneyDetailPage.tsx
@@ -13,15 +13,13 @@ import {
   Grid,
   Chip,
   Button,
-  TextareaAutosize,
 } from '@mui/material';
-import { getJourney, updateJourney, type Journey, type TestResult } from '../../api/journeys';
+import { getJourney, type Journey, type TestResult } from '../../api/journeys';
 import { ArrowBack } from '@mui/icons-material';
 
 export default function JourneyDetailPage() {
   const { id } = useParams<{ id: string }>();
   const [journey, setJourney] = useState<Journey | null>(null);
-  const [code, setCode] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -35,7 +33,6 @@ export default function JourneyDetailPage() {
       try {
         const data = await getJourney(id);
         setJourney(data);
-        setCode(data.code || '');
       } catch (err) {
         setError('Failed to fetch journey details.');
         console.error(err);
@@ -45,19 +42,6 @@ export default function JourneyDetailPage() {
     };
     fetchJourneyData();
   }, [id]);
-
-  const handleSave = async () => {
-    if (!id || !journey) return;
-    try {
-      const updatedJourney = await updateJourney(id, { name: journey.name, code });
-      setJourney(updatedJourney);
-      setCode(updatedJourney.code || '');
-      alert('Journey updated successfully!');
-    } catch (err) {
-      setError('Failed to update journey.');
-      console.error(err);
-    }
-  };
 
   if (loading) {
     return (
@@ -138,21 +122,6 @@ export default function JourneyDetailPage() {
             </ListItem>
           ))}
         </List>
-
-        <Divider sx={{ my: 2 }} />
-
-        <Typography variant="h6" gutterBottom>
-          Code
-        </Typography>
-        <TextareaAutosize
-          minRows={10}
-          style={{ width: '100%', fontFamily: 'monospace', padding: '8px' }}
-          value={code}
-          onChange={(e) => setCode(e.target.value)}
-        />
-        <Button variant="contained" onClick={handleSave} sx={{ mt: 2 }}>
-          Save Code
-        </Button>
 
         {journey.lastRun?.testResult && (
           <>

--- a/frontend/src/pages/journeys/JourneyEditor.tsx
+++ b/frontend/src/pages/journeys/JourneyEditor.tsx
@@ -1,13 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Box, Typography, Paper, Alert, CircularProgress } from '@mui/material';
+import { Box, Typography, Paper, Alert, CircularProgress, Button, Modal, TextareaAutosize } from '@mui/material';
 import JourneyForm from './JourneyForm';
 import { getJourney, updateJourney, type Journey, type JourneyStep } from '../../api/journeys';
 
 export default function JourneyEditor() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const [journey, setJourney] = useState<Journey | null>(null);
   const [initialData, setInitialData] = useState<{ name: string; steps: JourneyStep[] } | null>(null);
+  const [code, setCode] = useState<string>('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -19,8 +22,10 @@ export default function JourneyEditor() {
     }
     const fetchJourneyData = async () => {
       try {
-        const journey = await getJourney(id);
-        setInitialData({ name: journey.name, steps: journey.steps });
+        const journeyData = await getJourney(id);
+        setJourney(journeyData);
+        setInitialData({ name: journeyData.name, steps: journeyData.steps });
+        setCode(journeyData.code || '');
       } catch (err) {
         setError('Failed to fetch journey data.');
         console.error(err);
@@ -32,12 +37,26 @@ export default function JourneyEditor() {
   }, [id]);
 
   const handleSubmit = async (data: { name: string; steps: JourneyStep[] }) => {
-    if (!id) return;
+    if (!id || !journey) return;
     try {
-      await updateJourney(id, data);
+      await updateJourney(id, { ...data, domain: journey.domain });
       navigate('/journeys');
     } catch (err) {
       setError('Failed to update journey.');
+      console.error(err);
+    }
+  };
+
+  const handleCodeSave = async () => {
+    if (!id || !journey) return;
+    try {
+      const updatedJourney = await updateJourney(id, { name: journey.name, code });
+      setJourney(updatedJourney);
+      setInitialData({ name: updatedJourney.name, steps: updatedJourney.steps });
+      setCode(updatedJourney.code || '');
+      setIsModalOpen(false);
+    } catch (err) {
+      setError('Failed to update code.');
       console.error(err);
     }
   };
@@ -61,15 +80,47 @@ export default function JourneyEditor() {
       </Typography>
       <Paper>
         {initialData ? (
-          <JourneyForm
-            onSubmit={handleSubmit}
-            initialData={initialData}
-            submitButtonText="Update Journey"
-          />
+          <>
+            <Box sx={{ p: 2, display: 'flex', justifyContent: 'flex-end' }}>
+                <Button variant="outlined" onClick={() => setIsModalOpen(true)}>View/Edit Code</Button>
+            </Box>
+            <JourneyForm
+              onSubmit={handleSubmit}
+              initialData={initialData}
+              submitButtonText="Update Journey"
+            />
+          </>
         ) : (
           <Alert severity="info">Journey data could not be loaded.</Alert>
         )}
       </Paper>
+      <Modal open={isModalOpen} onClose={() => setIsModalOpen(false)}>
+        <Box sx={{ ...style, width: '80vw', maxHeight: '90vh', overflowY: 'auto' }}>
+          <Typography variant="h6" component="h2">
+            Journey Code
+          </Typography>
+          <TextareaAutosize
+            minRows={20}
+            style={{ width: '100%', fontFamily: 'monospace', padding: '8px', marginTop: '16px' }}
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+          />
+          <Button variant="contained" onClick={handleCodeSave} sx={{ mt: 2 }}>
+            Save Code
+          </Button>
+        </Box>
+      </Modal>
     </Box>
   );
 }
+
+const style = {
+  position: 'absolute' as 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  p: 4,
+};


### PR DESCRIPTION
This feature allows users to save their journeys as raw Playwright scripts, which can be edited and run directly.

- The `Journey` model has been updated to include a `code` field to store the raw Playwright script.
- The import process now saves the raw code to the database.
- The `runJourney` service has been updated to execute the Playwright script from the `code` field using `child_process`.
- The `parser.js` service has been updated to support `expect` assertions.
- The `JourneyEditor` page now includes a modal with a code editor, allowing users to view and edit the Playwright script.