### PR TITLE
feat: Allow saving journeys as Playwright scripts

### DIFF
--- a/frontend/src/pages/journeys/JourneyForm.tsx
+++ b/frontend/src/pages/journeys/JourneyForm.tsx
@@ -50,6 +50,13 @@ export default function JourneyForm({
     const newSteps = [...steps];
     if (field === 'action') {
       newSteps[index] = { ...newSteps[index], action: value, params: {} }; // Reset params on action change
+    } else if (field === 'selector' && typeof value === 'string') {
+      try {
+        newSteps[index].params.selector = JSON.parse(value);
+      } catch (e) {
+        // If parsing fails, it's probably a simple string selector
+        newSteps[index].params.selector = value;
+      }
     } else if (field in newSteps[index]) {
       (newSteps[index] as any)[field] = value;
     } else {
@@ -133,10 +140,12 @@ export default function JourneyForm({
         return (
           <TextField
             label="Selector"
-            value={step.params.selector || ''}
+            value={typeof step.params.selector === 'object' ? JSON.stringify(step.params.selector, null, 2) : step.params.selector || ''}
             onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
             fullWidth
             required
+            multiline
+            rows={4}
           />
         );
       case 'type':
@@ -145,10 +154,12 @@ export default function JourneyForm({
             <Grid item xs={6}>
               <TextField
                 label="Selector"
-                value={step.params.selector || ''}
+                value={typeof step.params.selector === 'object' ? JSON.stringify(step.params.selector, null, 2) : step.params.selector || ''}
                 onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
                 fullWidth
                 required
+                multiline
+                rows={4}
               />
             </Grid>
             <Grid item xs={6}>
@@ -173,10 +184,12 @@ export default function JourneyForm({
         return (
           <TextField
             label="Selector"
-            value={step.params.selector || ''}
+            value={typeof step.params.selector === 'object' ? JSON.stringify(step.params.selector, null, 2) : step.params.selector || ''}
             onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
             fullWidth
             required
+            multiline
+            rows={4}
           />
         );
       case 'toHaveText':
@@ -185,10 +198,12 @@ export default function JourneyForm({
             <Grid item xs={6}>
               <TextField
                 label="Selector"
-                value={step.params.selector || ''}
+                value={typeof step.params.selector === 'object' ? JSON.stringify(step.params.selector, null, 2) : step.params.selector || ''}
                 onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
                 fullWidth
                 required
+                multiline
+                rows={4}
               />
             </Grid>
             <Grid item xs={6}>
@@ -215,10 +230,12 @@ export default function JourneyForm({
             <Grid item xs={4}>
               <TextField
                 label="Selector"
-                value={step.params.selector || ''}
+                value={typeof step.params.selector === 'object' ? JSON.stringify(step.params.selector, null, 2) : step.params.selector || ''}
                 onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
                 fullWidth
                 required
+                multiline
+                rows={4}
               />
             </Grid>
             <Grid item xs={4}>


### PR DESCRIPTION
This feature allows users to save their journeys as raw Playwright scripts, which can be edited and run directly. It also provides two-way synchronization between the code and the step-based editor.

- The `Journey` model has been updated to include a `code` field to store the raw Playwright script.
- The import process now saves the raw code to the database.
- The `runJourney` service has been updated to execute the Playwright script from the `code` field using `child_process`.
- The `parser.js` service has been updated to support `expect` assertions.
- A new `code-generator.js` service has been created to generate Playwright code from steps.
- A new API endpoint `/api/journeys/generate-code` has been added.
- The `JourneyEditor` page now includes a modal with a code editor, allowing users to view and edit the Playwright script.
- The `JourneyEditor` now handles two-way synchronization between the code and the steps.
- The `JourneyForm` now correctly displays selector objects as JSON strings.