### PR TITLE
feat: Allow saving journeys as Playwright scripts

### DIFF
--- a/frontend/src/pages/journeys/JourneyForm.tsx
+++ b/frontend/src/pages/journeys/JourneyForm.tsx
@@ -122,6 +122,7 @@ export default function JourneyForm({
         return (
           <TextField
             label="URL"
+            placeholder="e.g., https://example.com"
             value={step.params.url || ''}
             onChange={(e) => handleStepChange(index, 'url', e.target.value)}
             fullWidth
@@ -139,7 +140,8 @@ export default function JourneyForm({
       case 'waitForSelector':
         return (
           <TextField
-            label="Selector"
+            label="Element Selector"
+            helperText="e.g., #login-button or .product-name"
             value={typeof step.params.selector === 'object' ? JSON.stringify(step.params.selector, null, 2) : step.params.selector || ''}
             onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
             fullWidth
@@ -153,7 +155,8 @@ export default function JourneyForm({
           <>
             <Grid item xs={6}>
               <TextField
-                label="Selector"
+                label="Element Selector"
+                helperText="e.g., #username"
                 value={typeof step.params.selector === 'object' ? JSON.stringify(step.params.selector, null, 2) : step.params.selector || ''}
                 onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
                 fullWidth
@@ -165,6 +168,7 @@ export default function JourneyForm({
             <Grid item xs={6}>
               <TextField
                 label="Text"
+                placeholder="Text to type"
                 value={step.params.text || ''}
                 onChange={(e) => handleStepChange(index, 'text', e.target.value)}
                 fullWidth
@@ -183,7 +187,8 @@ export default function JourneyForm({
       case 'toBeVisible':
         return (
           <TextField
-            label="Selector"
+            label="Element Selector"
+            helperText="e.g., #success-message"
             value={typeof step.params.selector === 'object' ? JSON.stringify(step.params.selector, null, 2) : step.params.selector || ''}
             onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
             fullWidth
@@ -197,7 +202,8 @@ export default function JourneyForm({
           <>
             <Grid item xs={6}>
               <TextField
-                label="Selector"
+                label="Element Selector"
+                helperText="e.g., h1"
                 value={typeof step.params.selector === 'object' ? JSON.stringify(step.params.selector, null, 2) : step.params.selector || ''}
                 onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
                 fullWidth
@@ -209,6 +215,7 @@ export default function JourneyForm({
             <Grid item xs={6}>
               <TextField
                 label="Text"
+                placeholder="Expected text"
                 value={step.params.text || ''}
                 onChange={(e) => handleStepChange(index, 'text', e.target.value)}
                 fullWidth
@@ -229,7 +236,8 @@ export default function JourneyForm({
           <>
             <Grid item xs={4}>
               <TextField
-                label="Selector"
+                label="Element Selector"
+                helperText="e.g., a.link"
                 value={typeof step.params.selector === 'object' ? JSON.stringify(step.params.selector, null, 2) : step.params.selector || ''}
                 onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
                 fullWidth
@@ -241,6 +249,7 @@ export default function JourneyForm({
             <Grid item xs={4}>
               <TextField
                 label="Attribute"
+                placeholder="e.g., href"
                 value={step.params.attribute || ''}
                 onChange={(e) => handleStepChange(index, 'attribute', e.target.value)}
                 fullWidth
@@ -250,6 +259,7 @@ export default function JourneyForm({
             <Grid item xs={4}>
               <TextField
                 label="Value"
+                placeholder="Expected value"
                 value={step.params.value || ''}
                 onChange={(e) => handleStepChange(index, 'value', e.target.value)}
                 fullWidth
@@ -306,13 +316,13 @@ export default function JourneyForm({
                   label="Action"
                   onChange={(e) => handleStepChange(index, 'action', e.target.value)}
                 >
-                  <MenuItem value="goto">Go To</MenuItem>
-                  <MenuItem value="click">Click</MenuItem>
-                  <MenuItem value="type">Type</MenuItem>
-                  <MenuItem value="waitForSelector">Wait For Selector</MenuItem>
-                  <MenuItem value="toBeVisible">Is Visible</MenuItem>
-                  <MenuItem value="toHaveText">Has Text</MenuItem>
-                  <MenuItem value="toHaveAttribute">Has Attribute</MenuItem>
+                  <MenuItem value="goto">Go To URL</MenuItem>
+                  <MenuItem value="click">Click on Element</MenuItem>
+                  <MenuItem value="type">Type Text</MenuItem>
+                  <MenuItem value="waitForSelector">Wait For Element</MenuItem>
+                  <MenuItem value="toBeVisible">Check if Element is Visible</MenuItem>
+                  <MenuItem value="toHaveText">Check for Text in Element</MenuItem>
+                  <MenuItem value="toHaveAttribute">Check for Element Attribute</MenuItem>
                 </Select>
               </FormControl>
             </Grid>


### PR DESCRIPTION
This feature allows users to save their journeys as raw Playwright scripts, which can be edited and run directly. It also provides two-way synchronization between the code and the step-based editor.

- The `Journey` model has been updated to include a `code` field to store the raw Playwright script.
- The import process now saves the raw code to the database.
- The `runJourney` service has been updated to execute the Playwright script from the `code` field using `child_process`.
- The `parser.js` service has been updated to support `expect` assertions.
- A new `code-generator.js` service has been created to generate Playwright code from steps.
- A new API endpoint `/api/journeys/generate-code` has been added.
- The `JourneyEditor` page now includes a modal with a code editor, allowing users to view and edit the Playwright script.
- The `JourneyEditor` now handles two-way synchronization between the code and the steps.
- The `JourneyForm` now correctly displays selector objects as JSON strings.
- The `JourneyForm` has been updated with more user-friendly labels and help text.