### PR TITLE
fix: Add support for `toContainText` assertion

### DIFF
--- a/backend/src/services/automation.js
+++ b/backend/src/services/automation.js
@@ -99,6 +99,12 @@ async function runJourney(journey) {
             await getAssertion(locator, processedParams.not).toHaveText(processedParams.text);
           }
           break;
+        case 'toContainText':
+            {
+              const locator = getLocator(processedParams.selector);
+              await getAssertion(locator, processedParams.not).toContainText(processedParams.text);
+            }
+            break;
         case 'toBeVisible':
           {
             const locator = getLocator(processedParams.selector);

--- a/backend/src/services/parser.js
+++ b/backend/src/services/parser.js
@@ -96,6 +96,48 @@ async function parsePlaywrightCode(filePath) {
           }
         }
       }
+
+      // Case 3: Assertions
+      let expectCall;
+      let isNot = false;
+
+      if (callee.object.type === 'CallExpression' && callee.object.callee.name === 'expect') {
+        expectCall = callee.object;
+      } else if (callee.object.type === 'MemberExpression' &&
+                 callee.object.property.name === 'not' &&
+                 callee.object.object.type === 'CallExpression' &&
+                 callee.object.object.callee.name === 'expect') {
+        expectCall = callee.object.object;
+        isNot = true;
+      }
+
+      if (expectCall) {
+        const action = callee.property.name;
+        const locatorCall = expectCall.arguments[0];
+
+        if (locatorCall.type === 'CallExpression' && locatorCall.callee.type === 'MemberExpression' && locatorCall.callee.object.name === 'page') {
+          const selector = {
+            method: locatorCall.callee.property.name,
+            args: locatorCall.arguments.map(convertNodeToValue),
+          };
+
+          const params = { selector };
+          if (isNot) {
+            params.not = true;
+          }
+
+          if (awaitArg.arguments.length > 0) {
+            if (action === 'toHaveText' || action === 'toContainText') {
+              params.text = convertNodeToValue(awaitArg.arguments[0]);
+            } else if (action === 'toHaveAttribute') {
+              params.attribute = convertNodeToValue(awaitArg.arguments[0]);
+              params.value = convertNodeToValue(awaitArg.arguments[1]);
+            }
+          }
+
+          steps.push({ action, params });
+        }
+      }
     },
   });
 

--- a/frontend/src/pages/journeys/JourneyForm.tsx
+++ b/frontend/src/pages/journeys/JourneyForm.tsx
@@ -180,6 +180,7 @@ export default function JourneyForm({
           />
         );
       case 'toHaveText':
+      case 'toContainText':
         return (
           <>
             <Grid item xs={6}>
@@ -295,6 +296,7 @@ export default function JourneyForm({
                   <MenuItem value="waitForSelector">Wait For Selector</MenuItem>
                   <MenuItem value="toBeVisible">Is Visible</MenuItem>
                   <MenuItem value="toHaveText">Has Text</MenuItem>
+                  <MenuItem value="toContainText">Contains Text</MenuItem>
                   <MenuItem value="toHaveAttribute">Has Attribute</MenuItem>
                 </Select>
               </FormControl>


### PR DESCRIPTION
This commit fixes a bug where the parser was not correctly handling `toContainText` assertions from imported Playwright scripts.

- The `parser.js` service has been updated to correctly parse `expect().toContainText()` statements.
- The `automation.js` step runner has been updated to handle the `toContainText` action.
- The `JourneyForm.tsx` has been updated to include "Contains Text" as a selectable action in the step editor.