### PR TITLE
feat: Enhance parser for chained calls and new actions

### DIFF
--- a/frontend/src/pages/journeys/JourneyForm.tsx
+++ b/frontend/src/pages/journeys/JourneyForm.tsx
@@ -169,6 +169,52 @@ export default function JourneyForm({
             </Grid>
           </>
         );
+      case 'press':
+        return (
+          <>
+            <Grid item xs={6}>
+              <TextField
+                label="Selector"
+                value={step.params.selector || ''}
+                onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={6}>
+              <TextField
+                label="Key"
+                value={step.params.text || ''}
+                onChange={(e) => handleStepChange(index, 'text', e.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+          </>
+        );
+      case 'selectOption':
+        return (
+          <>
+            <Grid item xs={6}>
+              <TextField
+                label="Selector"
+                value={step.params.selector || ''}
+                onChange={(e) => handleStepChange(index, 'selector', e.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={6}>
+              <TextField
+                label="Value"
+                value={step.params.value || ''}
+                onChange={(e) => handleStepChange(index, 'value', e.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+          </>
+        );
       case 'toBeVisible':
         return (
           <TextField
@@ -293,6 +339,8 @@ export default function JourneyForm({
                   <MenuItem value="goto">Go To</MenuItem>
                   <MenuItem value="click">Click</MenuItem>
                   <MenuItem value="type">Type</MenuItem>
+                  <MenuItem value="press">Press Key</MenuItem>
+                  <MenuItem value="selectOption">Select Option</MenuItem>
                   <MenuItem value="waitForSelector">Wait For Selector</MenuItem>
                   <MenuItem value="toBeVisible">Is Visible</MenuItem>
                   <MenuItem value="toHaveText">Has Text</MenuItem>


### PR DESCRIPTION
This feature enhances the Playwright script parser to handle more complex commands, including chained calls and new actions like `.selectOption()` and `.press()`.

- The `parser.js` service has been refactored to recursively parse chained calls, such as `.first().click()`.
- The parser now supports new actions: `press` and `selectOption`.
- The `automation.js` step runner has been updated to execute these new actions and the chained selector format.
- The `JourneyForm.tsx` has been updated to include the new actions in the step editor.