### PR TITLE
feat: Save journey Playwright scripts to files

### DIFF
--- a/backend/src/models/Journey.js
+++ b/backend/src/models/Journey.js
@@ -4,6 +4,7 @@ const JourneySchema = new mongoose.Schema({
   name: { type: String, required: true },
   domain: { type: String, required: true, trim: true, index: true },
   steps: { type: Array, required: true },
+  code: { type: String },
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   lastRun: {
     status: { type: String, enum: ['success', 'failure', 'pending'], default: 'pending' },

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -34,8 +34,14 @@ router.post('/journey', async (req, res) => {
       name,
       domain,
       steps,
+      code,
       user: req.user.id,
     });
+
+    const journeysDir = path.join(__dirname, '..', 'journeys');
+    await fs.mkdir(journeysDir, { recursive: true });
+    const journeyFile = path.join(journeysDir, `${journey._id}.js`);
+    await fs.writeFile(journeyFile, code);
 
     res.status(201).json(journey);
   } catch (error) {


### PR DESCRIPTION
This feature saves the Playwright code for each journey into a file on the backend filesystem, allowing users to have direct access to the raw `.js` files.

- A `journeys` directory has been created in the `backend` to store the script files.
- The `import`, `create`, and `update` routes for journeys have been updated to save the Playwright code to a file named `{journey_id}.js`.
- The `code` field has been re-introduced to the `Journey` model to store the script in the database.
- The `code-generator` service is used to generate code for journeys created manually or from templates.
- Two-way synchronization between the step editor and the code editor is handled in the `PUT /journeys/:id` route.